### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 Challenge du Berger
 =================
-**Avec deux gestes simples, rendons nos emails plus humains**
+**Avec deux gestes simples, rendons nos courriels plus humains**
 
-* Supprimons les formules de politesse qui sont ajoutées automatiquement à nos emails,
-* Bannissons le « cordialement » de nos emails.
+* Supprimons les formules de politesse qui sont ajoutées automatiquement à nos courriels,
+* Bannissons le « cordialement » de nos courriels.
 
 ### Supprimons les formules de politesse automatiques
-Le point de départ du *Challenge du Berger* est avant tout la suppression des formules de politesse automatiques incluses dans la signature de nos emails. Pour créer de véritables relations humaines, il faut que la formule de politesse retrouve sa fonction initiale : saluer respectueusement les destinataires. 
+Le point de départ du *Challenge du Berger* est avant tout la suppression des formules de politesse automatiques incluses dans la signature de nos courriels. Pour créer de véritables relations humaines, il faut que la formule de politesse retrouve sa fonction initiale : saluer respectueusement les destinataires. 
 
 Il n'est pas forcément aisé de trouver des formules de politesse adaptées à ses correspondants. C'est pourquoi, avec les différents contributeurs de ce GitHub, nous vous avons préparé [une longue liste de formules de politesse](https://github.com/desbenoit/ChallengeDuBerger/blob/master/Formules.md) en précisant les contextes où elles sont utilisables. 
 
@@ -16,16 +16,15 @@ Le *cordialemement* était une formule réellement chaleureuse. Elle est aujourd
 Le *cordialemement* peut toutefois toujours être une solution de facilité. Principalement dans le cadre d'échanges impersonnels d'où ne naitra aucune relation humaine. 
 
 ### Attention, les alternatives comportent des pièges
-Je ne signerai probablement jamais un email *pommement vôtre* ou encore *électriquement vôtre* à moins que l’échange ne comporte une forte dose de second degré voire de délire. Avec le *cordialement*, ce sont tous les néologismes avec le suffixe *-ment* qui sont à éviter. Les *sportivement*, *œnoliqueme*… ne viennent pas réellement améliorer la relation humaine. Bien qu'apportant une certaine légèreté, ces expressions à la mode dans les années 2000 peuvent donner un côté *has-been* à l’interlocuteur.
+Je ne signerai probablement jamais un courriel *pommement vôtre* ou encore *électriquement vôtre* à moins que l’échange ne comporte une forte dose de second degré voire de délire. Avec le *cordialement*, ce sont tous les néologismes avec le suffixe *-ment* qui sont à éviter. Les *sportivement*, *œnoliqueme*… ne viennent pas réellement améliorer la relation humaine. Bien qu'apportant une certaine légèreté, ces expressions à la mode dans les années 2000 peuvent donner un côté *has-been* à l’interlocuteur.
 
 ### Historique
-Initialement, le challenge du Berger était un « jeu » pour améliorer nos échanges par email créé par Sébastien Desbenoit et inspiré Jean-Louis Berger-Bordes : le *Berger*. Quatre ans après une conférence *éclair* à Paris-Web et la sortie du [premier article](http://blog.thinkinnovation.fr/Le-Challenge-du-Berger) sur le sujet, cette expression a pris un nouveau sens et est devenue l'étendard de cet acte simple de la vie du tous les jours : supprimer sa signature automatique et adapter la formule de politesse à la conversation.
+Initialement, le challenge du Berger était un « jeu » pour améliorer nos échanges par courriel créé par Sébastien Desbenoit et inspiré Jean-Louis Berger-Bordes : le *Berger*. Quatre ans après une conférence *éclair* à Paris-Web et la sortie du [premier article](http://blog.thinkinnovation.fr/Le-Challenge-du-Berger) sur le sujet, cette expression a pris un nouveau sens et est devenue l'étendard de cet acte simple de la vie du tous les jours : supprimer sa signature automatique et adapter la formule de politesse à la conversation.
 
 Depuis juin 2016, l'initiative connaît un nouveau souffle avec sa mise en lumière par [BFM Business](https://notes.desbenoit.net/Faire-disparaitre-le-cordialement).
 
 
 ## Trouver des alternatives au cordialement
-Le document [Formules.md](https://github.com/desbenoit/ChallengeDuBerger/blob/master/Formules.md) recense des formules de politesse à utiliser, combiner, améliorer pour vos emails. N'hésitez pas à contribuer en ajoutant vos signatures. 
+Le document [Formules.md](https://github.com/desbenoit/ChallengeDuBerger/blob/master/Formules.md) recense des formules de politesse à utiliser, combiner, améliorer pour vos courriels. N'hésitez pas à contribuer en ajoutant vos signatures. 
 
-Les contributions sont totalement libres dans la limite du respect d'autrui. 
-
+Les contributions sont totalement libres dans la limite du respect d'autrui.


### PR DESCRIPTION
Remplacement des termes "emails" par "courriels", ça fé plusse fraissais ! (cela fait effectivement plus français ) :P

Vous pouvez trouver plus d'informations sur cette page : http://romy.tetue.net/faut-il-dire-mail-ou-courriel

"D’origine québécoise (1990), le mot « courriel » est la contraction de « courrier électronique ». Il est agréablement explicite en plus d’être de jolie consonance, si bien que de nombreux locuteurices francophones l’ont adopté. Accepté par l’Académie française, présent dans les dictionnaires courants, ce terme a été rendu obligatoire en France pour les textes officiels, depuis le 20 juin 2003 par la DGLFLF."